### PR TITLE
Don't overwrite regex cache when configuring the tokenizer

### DIFF
--- a/tokenizer.js
+++ b/tokenizer.js
@@ -44,14 +44,14 @@ Tokenizer.prototype.configure = function (configuration) {
     charset = configuration.charset();
     exclude = configuration.delimiters();
 
-    this._regexes.alphanumeric = Tokenizer.compile(charset, exclude);
-
-    Tokenizer.cache.insert(configuration.toString(), {
+    this._regexes = {
       alpha: this._regexes.alpha,
-      alphanumeric: this._regexes.alphanumeric,
+      alphanumeric: Tokenizer.compile(charset, exclude),
       numeric: this._regexes.numeric,
       decimal: this._regexes.decimal
-    });
+    };
+
+    Tokenizer.cache.insert(configuration.toString(), this._regexes);
   }
 
   return this;


### PR DESCRIPTION
Create a new regexes object first, put it in the cache afterwards.