### PR TITLE
Reset to alphanumeric mode on tokenizer configure

### DIFF
--- a/tokenizer.js
+++ b/tokenizer.js
@@ -51,6 +51,8 @@ Tokenizer.prototype.configure = function (configuration) {
       decimal: this._regexes.decimal
     };
 
+    this.alphanumeric();
+
     Tokenizer.cache.insert(configuration.toString(), this._regexes);
   }
 


### PR DESCRIPTION
Prevent the tokenizer from using the old regex after reconfiguring.