### PR TITLE
Fix two parsers with same encoding

### DIFF
--- a/spec/MultipleParserIssueSpec.js
+++ b/spec/MultipleParserIssueSpec.js
@@ -1,0 +1,17 @@
+'use strict'
+
+let Parser = require('../parser.js');
+
+let msg = "UNB+UNOC:3+123:14+123:14+180813:0806+404114++LG'UNH+404114+MSCONS:D:04B:UN:2.1a'";
+
+
+it('Should accept sample message with two parsers & same encodings (config is cached)', function () {
+  let parser1 = new Parser();
+  parser1.encoding("UNOY");
+  let parser2 = new Parser();
+  parser2.encoding("UNOY");
+  expect(function() { parser1.write(msg); }).not.toThrow();
+  expect(function() { parser1.end(); }).not.toThrow();
+  expect(function() { parser2.write(msg); }).not.toThrow();
+  expect(function() { parser2.end(); }).not.toThrow();
+});

--- a/tokenizer.js
+++ b/tokenizer.js
@@ -39,6 +39,7 @@ Tokenizer.prototype.configure = function (configuration) {
 
   if (Tokenizer.cache.contains(configuration.toString())) {
     this._regexes = Tokenizer.cache.get(configuration.toString());
+    this.alphanumeric();
   } else {
     // Reconfigure if the charset was changed.
     charset = configuration.charset();


### PR DESCRIPTION
When instantiating two parsers with the same encoding, I get the following error, which is fixed by this pull request

```
        throw Parser.errors.invalidCharacter(chunk.charAt(index), index);
        ^

Error: Invalid character a at position 104
    at Object.invalidCharacter (sample/node_modules/edifact/parser.js:231:12)
    at Parser.write (sample/node_modules/edifact/parser.js:204:29)
    at Object.parse (sample/parser/sample.js:90:10)
    at sample (sample/test/helper/dumper.js:15:17)
    at Command.program.command.action (sample/test/helper/dumper.js:37:32)
    at Command.listener (sample/node_modules/commander/index.js:315:8)
    at emitTwo (events.js:126:13)
    at Command.emit (events.js:214:7)
    at Command.parseArgs (sample/node_modules/commander/index.js:651:12)
    at Command.parse (sample/node_modules/commander/index.js:474:21) 
```