### PR TITLE
Reset regex after Tokenizer configuration from cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "edifact",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "JavaScript parser for UN/EDIFACT documents.",
-  "keywords": ["edifact", "edi", "eancom"],
+  "keywords": [
+    "edifact",
+    "edi",
+    "eancom"
+  ],
   "main": "index.js",
   "engines": {
     "node": ">=0.12"

--- a/tokenizer.js
+++ b/tokenizer.js
@@ -28,7 +28,6 @@ var Tokenizer = function (configuration) {
   };
 
   this.configure(configuration);
-  this._regex = this._regexes.alphanumeric;
 
   this.buffer = '';
 }
@@ -51,10 +50,10 @@ Tokenizer.prototype.configure = function (configuration) {
       decimal: this._regexes.decimal
     };
 
-    this.alphanumeric();
-
     Tokenizer.cache.insert(configuration.toString(), this._regexes);
   }
+
+  this.alphanumeric();
 
   return this;
 }


### PR DESCRIPTION
When the corresponding regexes are found in the cache, the current regex wasn't being updated correctly. Resolves bug #33.