### PR TITLE
Fix the reader interface for parsing messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edifact",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "JavaScript parser for UN/EDIFACT documents.",
   "keywords": [
     "edifact",

--- a/reader.js
+++ b/reader.js
@@ -64,7 +64,8 @@ Reader.prototype.define = function (definitions) {
  * @returns {Array} An array of segment objects.
  */
 Reader.prototype.parse = function (document) {
-  this._parser.write(document).close();
+  this._parser.write(document);
+  this._parser.close();
   return this._result;
 }
 


### PR DESCRIPTION
The Parser `write()` method did not return `this` resulting in an error in the Reader class.